### PR TITLE
Fix version number not starting with number

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ apply plugin: 'net.minecraftforge.gradle'
 apply plugin: 'eclipse'
 apply plugin: 'maven-publish'
 
-version = "beta-${mod_version}"
+version = "${mod_version}-beta"
 group = "guntram.${modid}" // http://maven.apache.org/guides/mini/guide-naming-conventions.html
 archivesBaseName = "${modid}"
 

--- a/build.gradle
+++ b/build.gradle
@@ -80,7 +80,7 @@ dependencies {
 
     annotationProcessor 'org.spongepowered:mixin:0.8.5:processor' //Re-enable when building jar
 
-    implementation fg.deobf("maven.modrinth:ellemes-container-library:1.4.0-beta.2+forge")
+    implementation fg.deobf("curse.maven:ellemes-container-library1.4.0-beta.2+forge-530668:3813786")
     implementation fg.deobf("curse.maven:sophisticated-core-618298:3847441")
     implementation fg.deobf("curse.maven:sophisticated-backpacks-422301:3847503")
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 org.gradle.jvmargs=-Xmx3G
 org.gradle.daemon=false
-mod_version=1.0.4
+mod_version=1.0.5
 modid=easierchests
 mc_version=1.18.2
 forge_version=40.1.54


### PR DESCRIPTION
The mod crashes on instance load. The exception is:
"Version string does not start with a number".

Move the "beta" string to the end of the version property instead of the beginning.
Bump mod_version from 1.0.4 to 1.0.5

fixes https://github.com/ArtixAllMighty/EasierChests-Forge/issues/5